### PR TITLE
Add newer functionality to the CRUD endpoints for clean date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Shale Tasks API
 
+## Details
+
+This project is deployed on GKE with a MongoDB data layer as a 3 node stateful set. There is a TLS reverse proxy
+in place, however, the let's encrypt token isn't quite working correctly that may or may not be an error in the
+proxy's deployment. A postman library has been added to hit the endpoints, but one must turn off the `SSL certificate verification`
+setting to make it work in its current state. All repos regarding the project can be found [here](https://github.com/matthewberryhill).
+Both the proxy service and the tasks-api service are scaled to 3 nodes on the cluster.
+
 [Project Management](https://github.com/orgs/matthewberryhill/projects/1)
 
 ## Development
@@ -22,6 +30,7 @@ $ dep ensure
 ### Run Locally
  
 ```bash
+$ cd $GOPATH/src/github.com/matthewberryhill/shale-tasks-api
 # point to local mongo instance
 $ export MONGO=dev
 # up local mongoDB instance
@@ -29,7 +38,6 @@ $ docker-compose -f mongo-compose.yaml up -d
 # see mongo running
 $ docker ps
 # run app
-$ cd $GOPATH/src/github.com/matthewberryhill/shale-tasks-api
 $ go run main.go
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ $ go run main.go
 
 ## API Spec
 
+**Use the following URL to hit the endpoints**
+
+`https://matthewberryhill.com`
+
 ### GET/config
 
 **Headers**
@@ -93,6 +97,7 @@ Content-Type: application/json
   "id": {string},
   "task": {string},
   "date_created": {unix_timestamp},
+  "date_completed": {unix_timestamp},
   "completed": {bool}
 }
 ```
@@ -122,6 +127,7 @@ Accept: application/json
     "id": {string},
     "task": {string},
     "date_created": {unix_timestamp},
+    "date_completed": {unix_timestamp},
     "completed": {bool}
   }
 ]
@@ -155,6 +161,7 @@ id: {string}
   "id": {string},
   "task": {string},
   "date_created": {unix_timestamp},
+  "date_completed": {unix_timestamp},
   "completed": {bool}
 }
 ```
@@ -197,11 +204,14 @@ id: {string}
 
 *Task cannot share the same string as the task field*
 
+*Once a task in complete, that task cannot be incomplete*
+
 ```
 {
   "id": {string},
   "task": {string},
   "date_created": {unix_timestamp},
+  "date_completed": {unix_timestamp},
   "completed": {bool}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Content-Type: application/json
 
 **Request Payload**
 
+*Task cannot share the same string as the task field*
+
 ```
 {
   "task": {string},
@@ -100,6 +102,7 @@ Content-Type: application/json
 ```text
 201: Created
 400: Bad Request
+409: Conflict
 500: Internal Server Error
 ```
 
@@ -192,6 +195,8 @@ id: {string}
 
 **Response Payload**
 
+*Task cannot share the same string as the task field*
+
 ```
 {
   "id": {string},
@@ -207,6 +212,7 @@ id: {string}
 200: Ok
 400: Bad Request
 404: Not Found
+409: Conflict
 500: Internal Server Error
 ```
 

--- a/models/config_model.go
+++ b/models/config_model.go
@@ -10,7 +10,7 @@ type Config struct {
 func GetConfig() *Config {
 	c := new(Config)
 	c.Name = "shale-tasks-api"
-	c.Version = "0.0.1"
+	c.Version = "0.0.2"
 	c.Environment = "prod"
 	c.Error = ""
 

--- a/models/config_model.go
+++ b/models/config_model.go
@@ -10,7 +10,7 @@ type Config struct {
 func GetConfig() *Config {
 	c := new(Config)
 	c.Name = "shale-tasks-api"
-	c.Version = "0.0.0"
+	c.Version = "0.0.1"
 	c.Environment = "prod"
 	c.Error = ""
 

--- a/models/task_model.go
+++ b/models/task_model.go
@@ -21,6 +21,7 @@ type Task struct {
 	Id          *bson.ObjectId `json:"id" bson:"_id"`
 	Task        string         `json:"task"`
 	DateCreated *time.Time     `json:"date_created"`
+	DateCompleted *time.Time   `json:"date_completed"`
 	Completed   bool           `json:"completed"`
 }
 

--- a/server/tasks.go
+++ b/server/tasks.go
@@ -24,6 +24,12 @@ func CreateTask(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, err)
 	}
 
+	if tp.Task == "" {
+		er := new(responseError)
+		er.Error = "Request payload requires the 'task' field"
+		return c.JSON(http.StatusBadRequest, er)
+	}
+
 	ts, err := models.GetTasks()
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err)

--- a/shale-prod.postman_environment.json
+++ b/shale-prod.postman_environment.json
@@ -1,0 +1,16 @@
+{
+  "id": "032dfe71-37a8-7421-a10b-54cb48e98c93",
+  "name": "shale-prod",
+  "values": [
+    {
+      "enabled": true,
+      "key": "uri",
+      "value": "https://35.225.106.44",
+      "type": "text"
+    }
+  ],
+  "timestamp": 1540778285912,
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2018-10-29T03:58:55.209Z",
+  "_postman_exported_using": "Postman/5.5.3"
+}

--- a/shale-tasks.postman_collection.json
+++ b/shale-tasks.postman_collection.json
@@ -1,0 +1,143 @@
+{
+	"variables": [],
+	"info": {
+		"name": "shale-tasks",
+		"_postman_id": "7239f648-b501-2a7f-725b-0b9d613dec67",
+		"description": "",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "POST/tasks",
+			"request": {
+				"url": "{{uri}}/tasks",
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"task\": \"testerr\"\n}"
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "GET/tasks",
+			"request": {
+				"url": "{{uri}}/tasks",
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"task\": \"test\"\n}"
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "GET/tasks/:id",
+			"request": {
+				"url": "{{uri}}/tasks/5bd651f7b1b9227a9ba1c8dd",
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"task\": \"test\"\n}"
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "PUT/tasks/:id",
+			"request": {
+				"url": "{{uri}}/tasks/5bd65915b1b9220e03351f8a",
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"description": ""
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"completed\": false\n}"
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "DELETE/tasks",
+			"request": {
+				"url": "{{uri}}/tasks/5bd67753b1b9226f8f9de5dd",
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"task\": \"test\"\n}"
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		{
+			"name": "POST/config",
+			"request": {
+				"url": "{{uri}}/config",
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {},
+				"description": ""
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
This PR implements the follow: v0.0.2
+ [Force POST/tasks & PUT/tasks to not have the same name](https://github.com/matthewberryhill/shale-tasks-api/issues/18)
+ [Require the `task` field in the POST/tasks endpoint](https://github.com/matthewberryhill/shale-tasks-api/issues/19)
+ [Add a `date_completed` field to a Task](https://github.com/matthewberryhill/shale-tasks-api/issues/20)